### PR TITLE
Prevent extension UUID leak via Origin on Firefox.

### DIFF
--- a/src/features/utils.js
+++ b/src/features/utils.js
@@ -1,5 +1,23 @@
+
+function fetchPolyfill(url) {
+  return new Promise((resolve) => {
+    const req = new XMLHttpRequest();
+    req.withCredentials = true;
+    req.addEventListener('load', () => {
+      console.log('loaded', url);
+      resolve({
+        status: req.status,
+        statusText: req.statusText,
+        text: () => Promise.resolve(req.responseText),
+      });
+    });
+    req.open('GET', url);
+    req.send();
+  });
+}
+
 export async function fetchDocument(url, format = 'html') { // eslint-disable-line import/prefer-default-export
-  const response = await fetch(url, { credentials: 'include' });
+  const response = await fetchPolyfill(url);
 
   if (response.status !== 200) {
     throw Error(response.statusText);


### PR DESCRIPTION
On Firefox fetch requests have a `Origin` header attached which contains a unique value ([Bugzilla Issue](https://bugzilla.mozilla.org/show_bug.cgi?id=1405971)). When the extension is fetching privacy settings for google and facebook, this header is included, and could be used by google/facebook for linking accounts or sessions.

This PR fixes the issue by using `XMLHttpRequest` for fetching these pages instead of fetch. Once Firefox 64 is release this should be fixed and we can revert this change.

cc @konark-cliqz 