### PR TITLE
Do not rely on URL in page context.

### DIFF
--- a/src/content-page-bridge.js
+++ b/src/content-page-bridge.js
@@ -1,7 +1,5 @@
 /* eslint-disable no-underscore-dangle */
 
-import checkIsWhiteListed from './consent/whitelist';
-
 function queryCmp(method) {
   const cmpPromise = new Promise((resolve) => {
     window.__cmp(method, null, resolve);
@@ -33,13 +31,6 @@ const sendConsentMessage = (consent) => {
 };
 
 async function cmpCheck(retries) {
-  const isWhiteListed = checkIsWhiteListed(window.location);
-
-  if (isWhiteListed) {
-    sendConsentMessage(null);
-    return;
-  }
-
   if (window.__cmp === undefined) {
     if (retries > 0) {
       setTimeout(() => cmpCheck(retries - 1), 1000);

--- a/src/content.js
+++ b/src/content.js
@@ -5,6 +5,7 @@ import reducer from './reducer';
 import { getApplicationState } from './selectors';
 import { APPLICATION_STATE } from './constants';
 import { checkIsChrome } from './utils';
+import checkIsWhiteListed from './consent/whitelist';
 
 const url = window.location.href;
 
@@ -72,6 +73,11 @@ store.subscribe(() => {
 window.addEventListener('message', (event) => {
   if (event.source === window && event.data && event.data.source === 'content-page-bridge') {
     if (event.data.type === 'receivedConsent') {
+      const isWhiteListed = checkIsWhiteListed(window.location);
+      if (isWhiteListed) {
+        browser.runtime.sendMessage({ type: 'detectConsent', consent: null });
+        return;
+      }
       browser.runtime.sendMessage({ type: 'detectConsent', consent: event.data.consent });
     }
   }


### PR DESCRIPTION
Globals such as `URL` can be overridden by the page, causing the page-script
to break the page. This is currently happening on windeln.de.

This PR fixes the issue by moving the code that uses `URL` to the sandboxed content-script context.